### PR TITLE
Add online synchronization support with remote backend

### DIFF
--- a/bulletin_app/lib/data/remote/sync_api_client.dart
+++ b/bulletin_app/lib/data/remote/sync_api_client.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/models.dart';
+
+class SyncApiException implements Exception {
+  SyncApiException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() =>
+      'SyncApiException(statusCode: $statusCode, message: $message)';
+}
+
+class SyncApiClient {
+  SyncApiClient({
+    required Uri baseUri,
+    http.Client? httpClient,
+  })  : _baseUri = baseUri,
+        _httpClient = httpClient ?? http.Client();
+
+  final Uri _baseUri;
+  final http.Client _httpClient;
+
+  Uri _endpoint(String path, [Map<String, String>? queryParameters]) {
+    final normalized = path.startsWith('/') ? path.substring(1) : path;
+    final base = _baseUri.toString().endsWith('/')
+        ? _baseUri
+        : Uri.parse('${_baseUri.toString()}/');
+    final resolved = base.resolve(normalized);
+    if (queryParameters == null) {
+      return resolved;
+    }
+    return resolved.replace(queryParameters: queryParameters);
+  }
+
+  Future<void> pushSnapshot(SyncSnapshot snapshot) async {
+    final response = await _httpClient.post(
+      _endpoint('sync/push'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode(snapshot.toJson()),
+    );
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return;
+    }
+    throw SyncApiException(
+      'Échec de l\'envoi des données (${response.statusCode})',
+      statusCode: response.statusCode,
+    );
+  }
+
+  Future<SyncSnapshot?> pullSnapshot({DateTime? since}) async {
+    final query = <String, String>{};
+    if (since != null) {
+      query['since'] = since.toUtc().toIso8601String();
+    }
+    final response = await _httpClient.get(
+      _endpoint('sync/pull', query.isEmpty ? null : query),
+    );
+    if (response.statusCode == 204 || response.body.trim().isEmpty) {
+      return null;
+    }
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return SyncSnapshot.fromJson(data);
+    }
+    throw SyncApiException(
+      'Échec de la récupération (${response.statusCode})',
+      statusCode: response.statusCode,
+    );
+  }
+}

--- a/bulletin_app/lib/data/repositories/sync_repository.dart
+++ b/bulletin_app/lib/data/repositories/sync_repository.dart
@@ -1,0 +1,60 @@
+import 'package:http/http.dart' as http;
+
+import '../local/app_database.dart';
+import '../models/models.dart';
+import '../remote/sync_api_client.dart';
+
+class SyncException implements Exception {
+  SyncException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SyncException: $message';
+}
+
+class SyncRepository {
+  SyncRepository(this._db, this._httpClient);
+
+  final AppDatabase _db;
+  final http.Client _httpClient;
+
+  Future<SyncMetadata> loadMetadata() => _db.loadSyncMetadata();
+
+  Future<SyncMetadata> synchronize({required Uri endpoint}) async {
+    final metadata = await _db.loadSyncMetadata();
+    final client = SyncApiClient(baseUri: endpoint, httpClient: _httpClient);
+
+    try {
+      final snapshot = await _db.exportSnapshot();
+      await client.pushSnapshot(snapshot);
+      final remoteSnapshot = await client.pullSnapshot(
+        since: metadata.lastSyncedAt,
+      );
+      if (remoteSnapshot != null) {
+        await _db.applySnapshot(remoteSnapshot);
+      }
+      final updated = metadata.copyWith(
+        lastSyncedAt: DateTime.now(),
+        lastStatus: SyncStatus.success,
+        clearError: true,
+      );
+      await _db.upsertSyncMetadata(updated);
+      return updated;
+    } on SyncApiException catch (e) {
+      final failure = metadata.copyWith(
+        lastStatus: SyncStatus.error,
+        lastError: e.message,
+      );
+      await _db.upsertSyncMetadata(failure);
+      throw SyncException(e.message);
+    } catch (e) {
+      final failure = metadata.copyWith(
+        lastStatus: SyncStatus.error,
+        lastError: e.toString(),
+      );
+      await _db.upsertSyncMetadata(failure);
+      throw SyncException('Erreur de synchronisation: $e');
+    }
+  }
+}

--- a/bulletin_app/lib/logic/providers/sync_controller.dart
+++ b/bulletin_app/lib/logic/providers/sync_controller.dart
@@ -1,0 +1,256 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/models/models.dart';
+import '../../data/repositories/sync_repository.dart';
+
+class SyncState {
+  const SyncState({
+    this.initialized = false,
+    this.isOnline = true,
+    this.isSyncing = false,
+    this.syncEnabled = false,
+    this.remoteEndpoint = '',
+    this.interval = const Duration(minutes: 15),
+    this.lastSuccessfulSync,
+    this.lastError,
+    this.status = SyncStatus.idle,
+  });
+
+  final bool initialized;
+  final bool isOnline;
+  final bool isSyncing;
+  final bool syncEnabled;
+  final String remoteEndpoint;
+  final Duration interval;
+  final DateTime? lastSuccessfulSync;
+  final String? lastError;
+  final SyncStatus status;
+
+  bool get hasConfiguration => remoteEndpoint.isNotEmpty;
+
+  bool get canSync =>
+      syncEnabled && hasConfiguration && isOnline && !isSyncing;
+
+  SyncState copyWith({
+    bool? initialized,
+    bool? isOnline,
+    bool? isSyncing,
+    bool? syncEnabled,
+    String? remoteEndpoint,
+    Duration? interval,
+    DateTime? lastSuccessfulSync,
+    String? lastError,
+    bool clearError = false,
+    SyncStatus? status,
+  }) {
+    return SyncState(
+      initialized: initialized ?? this.initialized,
+      isOnline: isOnline ?? this.isOnline,
+      isSyncing: isSyncing ?? this.isSyncing,
+      syncEnabled: syncEnabled ?? this.syncEnabled,
+      remoteEndpoint: remoteEndpoint ?? this.remoteEndpoint,
+      interval: interval ?? this.interval,
+      lastSuccessfulSync: lastSuccessfulSync ?? this.lastSuccessfulSync,
+      lastError: clearError ? null : (lastError ?? this.lastError),
+      status: status ?? this.status,
+    );
+  }
+}
+
+class SyncController extends StateNotifier<SyncState> {
+  SyncController(
+    this._repository,
+    this._connectivity,
+    this._ref, {
+    required ProviderListenable<AsyncValue<ParametresApp>> parametresProvider,
+  })  : _parametresProvider = parametresProvider,
+        super(const SyncState());
+
+  final SyncRepository _repository;
+  final Connectivity _connectivity;
+  final Ref _ref;
+
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySub;
+  ProviderSubscription<AsyncValue<ParametresApp>>? _paramsSub;
+  Timer? _timer;
+  bool _initialized = false;
+  final ProviderListenable<AsyncValue<ParametresApp>> _parametresProvider;
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+
+    final metadata = await _repository.loadMetadata();
+    state = state.copyWith(
+      initialized: true,
+      lastSuccessfulSync: metadata.lastSyncedAt,
+      status: metadata.lastStatus,
+      lastError: metadata.lastError,
+      clearError: metadata.lastError == null,
+    );
+
+    final initialParams = _ref.read(_parametresProvider).maybeWhen(
+          data: (value) => value,
+          orElse: () => ParametresApp.defaults,
+        );
+    _applyParams(initialParams);
+
+    final initialConnectivity = await _connectivity.checkConnectivity();
+    _setOnline(initialConnectivity != ConnectivityResult.none);
+
+    _connectivitySub =
+        _connectivity.onConnectivityChanged.listen(_handleConnectivityEvent);
+    _paramsSub = _ref.listen<AsyncValue<ParametresApp>>(
+      _parametresProvider,
+      (previous, next) {
+        next.whenData(_applyParams);
+      },
+    );
+
+    _restartTimer();
+    if (state.syncEnabled && state.isOnline && state.hasConfiguration) {
+      unawaited(syncNow());
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _connectivitySub?.cancel();
+    _paramsSub?.close();
+    super.dispose();
+  }
+
+  Future<void> syncNow({bool manual = false}) async {
+    if (state.isSyncing) {
+      return;
+    }
+    if (!state.hasConfiguration) {
+      throw SyncException('Aucun serveur de synchronisation configuré.');
+    }
+    if (!state.isOnline) {
+      throw SyncException('Pas de connexion réseau disponible.');
+    }
+    if (!manual && !state.syncEnabled) {
+      return;
+    }
+
+    late Uri endpoint;
+    try {
+      endpoint = Uri.parse(state.remoteEndpoint);
+      if (!endpoint.hasScheme) {
+        throw const FormatException('missing scheme');
+      }
+    } catch (_) {
+      state = state.copyWith(
+        isSyncing: false,
+        status: SyncStatus.error,
+        lastError: 'URL du serveur invalide',
+      );
+      throw SyncException('URL du serveur invalide');
+    }
+
+    state = state.copyWith(
+      isSyncing: true,
+      status: SyncStatus.syncing,
+    );
+
+    try {
+      final metadata = await _repository.synchronize(endpoint: endpoint);
+      state = state.copyWith(
+        isSyncing: false,
+        status: metadata.lastStatus,
+        lastSuccessfulSync: metadata.lastSyncedAt,
+        clearError: true,
+      );
+    } on SyncException catch (e) {
+      state = state.copyWith(
+        isSyncing: false,
+        status: state.isOnline ? SyncStatus.error : SyncStatus.offline,
+        lastError: e.message,
+      );
+      rethrow;
+    } catch (e) {
+      state = state.copyWith(
+        isSyncing: false,
+        status: SyncStatus.error,
+        lastError: e.toString(),
+      );
+      throw SyncException('Erreur inattendue: $e');
+    }
+  }
+
+  void _applyParams(ParametresApp params) {
+    final normalizedEndpoint = params.remoteEndpoint.trim();
+    final prevEnabled = state.syncEnabled;
+    final prevInterval = state.interval;
+    final enable = params.syncEnabled && normalizedEndpoint.isNotEmpty;
+    final newInterval = Duration(minutes: params.syncIntervalMinutes);
+
+    var newState = state.copyWith(
+      syncEnabled: enable,
+      remoteEndpoint: normalizedEndpoint,
+      interval: newInterval,
+    );
+
+    if (!enable) {
+      newState = newState.copyWith(
+        status: newState.status == SyncStatus.syncing
+            ? SyncStatus.idle
+            : newState.status,
+        isSyncing: false,
+      );
+    }
+    state = newState;
+
+    if (!enable) {
+      _timer?.cancel();
+      return;
+    }
+
+    if (!prevEnabled || prevInterval != newInterval) {
+      _restartTimer();
+    }
+
+    if (!prevEnabled && state.canSync) {
+      unawaited(syncNow());
+    }
+  }
+
+  void _restartTimer() {
+    _timer?.cancel();
+    if (!state.syncEnabled || state.interval.inSeconds <= 0) {
+      return;
+    }
+    _timer = Timer.periodic(state.interval, (_) {
+      if (state.canSync) {
+        unawaited(syncNow());
+      }
+    });
+  }
+
+  void _handleConnectivityEvent(List<ConnectivityResult> results) {
+    final online = results.any((result) => result != ConnectivityResult.none);
+    _setOnline(online);
+  }
+
+  void _setOnline(bool online) {
+    final wasOnline = state.isOnline;
+    SyncStatus newStatus = state.status;
+    if (!online && state.status != SyncStatus.error && state.status != SyncStatus.syncing) {
+      newStatus = SyncStatus.offline;
+    } else if (online && state.status == SyncStatus.offline) {
+      newStatus = SyncStatus.idle;
+    }
+    state = state.copyWith(isOnline: online, status: newStatus);
+
+    if (online && !wasOnline && state.syncEnabled && state.canSync) {
+      unawaited(syncNow());
+    }
+  }
+}

--- a/bulletin_app/lib/ui/screens/facture_list_screen.dart
+++ b/bulletin_app/lib/ui/screens/facture_list_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import '../../data/models/models.dart';
+import '../../data/repositories/sync_repository.dart';
 import '../../logic/providers/current_facture_provider.dart';
 import '../../logic/providers/factures_list_provider.dart';
+import '../../logic/providers/sync_controller.dart';
 import '../widgets/facture_card.dart';
 import 'facture_edit_screen.dart';
 import 'settings_screen.dart';
@@ -36,11 +39,55 @@ class _FactureListScreenState extends ConsumerState<FactureListScreen> {
   Widget build(BuildContext context) {
     final facturesState = ref.watch(facturesListProvider);
     final status = ref.watch(factureStatusFilterProvider);
+    final syncState = ref.watch(syncControllerProvider);
 
     return Scaffold(
       appBar: AppBar(
         title: const Text("Factures / Bulletins d'achat"),
         actions: [
+          IconButton(
+            icon: syncState.isSyncing
+                ? const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Icon(
+                    _syncIcon(syncState),
+                    color: _syncIconColor(Theme.of(context), syncState),
+                  ),
+            tooltip: _syncTooltip(syncState),
+            onPressed: (!syncState.hasConfiguration || syncState.isSyncing)
+                ? null
+                : () async {
+                    try {
+                      await ref
+                          .read(syncControllerProvider.notifier)
+                          .syncNow(manual: true);
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Synchronisation terminée'),
+                        ),
+                      );
+                    } on SyncException catch (e) {
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content:
+                              Text('Erreur de synchronisation: ${e.message}'),
+                        ),
+                      );
+                    } catch (e) {
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Erreur inattendue: $e'),
+                        ),
+                      );
+                    }
+                  },
+          ),
           DropdownButtonHideUnderline(
             child: DropdownButton<FactureStatus?>(
               value: status,
@@ -99,6 +146,8 @@ class _FactureListScreenState extends ConsumerState<FactureListScreen> {
               },
             ),
             const SizedBox(height: 16),
+            _SyncStatusBanner(state: syncState),
+            const SizedBox(height: 16),
             Expanded(
               child: facturesState.when(
                 data: (factures) => _buildList(factures),
@@ -145,5 +194,154 @@ class _FactureListScreenState extends ConsumerState<FactureListScreen> {
       separatorBuilder: (_, __) => const SizedBox(height: 8),
       itemCount: factures.length,
     );
+  }
+
+  IconData _syncIcon(SyncState state) {
+    switch (state.status) {
+      case SyncStatus.error:
+        return Icons.sync_problem;
+      case SyncStatus.offline:
+        return Icons.cloud_off;
+      case SyncStatus.success:
+        return Icons.cloud_done;
+      case SyncStatus.syncing:
+        return Icons.sync;
+      case SyncStatus.idle:
+      default:
+        return Icons.sync;
+    }
+  }
+
+  Color? _syncIconColor(ThemeData theme, SyncState state) {
+    switch (state.status) {
+      case SyncStatus.error:
+        return theme.colorScheme.error;
+      case SyncStatus.offline:
+        return theme.colorScheme.outline;
+      case SyncStatus.success:
+        return theme.colorScheme.secondary;
+      default:
+        return null;
+    }
+  }
+
+  String _syncTooltip(SyncState state) {
+    if (!state.hasConfiguration) {
+      return 'Configurer un serveur distant dans les paramètres';
+    }
+    if (state.isSyncing) {
+      return 'Synchronisation en cours';
+    }
+    if (!state.isOnline) {
+      return 'Hors ligne';
+    }
+    if (state.lastSuccessfulSync != null) {
+      final formatter = DateFormat('dd/MM/yyyy HH:mm');
+      return 'Dernière synchronisation: ${formatter.format(state.lastSuccessfulSync!)}';
+    }
+    return 'Synchroniser maintenant';
+  }
+}
+
+class _SyncStatusBanner extends StatelessWidget {
+  const _SyncStatusBanner({required this.state});
+
+  final SyncState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final icon = _iconForStatus(state.status);
+    final color = _colorForStatus(theme, state.status);
+    final formatter = DateFormat('dd/MM/yyyy HH:mm');
+
+    final messages = <String>[];
+
+    if (state.isSyncing) {
+      messages.add('Synchronisation en cours...');
+    } else if (!state.isOnline) {
+      messages.add(
+        'Hors ligne - les données seront synchronisées dès le retour du réseau.',
+      );
+    } else if (!state.hasConfiguration) {
+      messages.add(
+        'Configurez un serveur distant dans les paramètres pour activer la synchronisation.',
+      );
+    } else if (state.status == SyncStatus.error && state.lastError != null) {
+      messages.add(state.lastError!);
+    } else if (state.syncEnabled) {
+      messages.add(
+        'Synchronisation automatique toutes les ${state.interval.inMinutes} minutes.',
+      );
+    } else {
+      messages.add(
+        'Synchronisation manuelle disponible via le bouton en haut à droite.',
+      );
+    }
+
+    if (state.lastSuccessfulSync != null &&
+        !(state.status == SyncStatus.error && state.lastError != null)) {
+      messages.add(
+        'Dernière synchro: ${formatter.format(state.lastSuccessfulSync!)}',
+      );
+    }
+
+    final title = () {
+      switch (state.status) {
+        case SyncStatus.syncing:
+          return 'Synchronisation en cours';
+        case SyncStatus.success:
+          return 'Synchronisation réussie';
+        case SyncStatus.error:
+          return 'Erreur de synchronisation';
+        case SyncStatus.offline:
+          return 'Mode hors ligne';
+        case SyncStatus.idle:
+          return state.syncEnabled
+              ? 'Synchronisation prête'
+              : 'Synchronisation en attente';
+      }
+    }();
+
+    return Card(
+      child: ListTile(
+        leading: Icon(icon, color: color),
+        title: Text(title),
+        subtitle: Text(messages.join('\n')),
+        isThreeLine: messages.length > 1,
+      ),
+    );
+  }
+
+  static IconData _iconForStatus(SyncStatus status) {
+    switch (status) {
+      case SyncStatus.error:
+        return Icons.sync_problem;
+      case SyncStatus.offline:
+        return Icons.cloud_off;
+      case SyncStatus.success:
+        return Icons.cloud_done;
+      case SyncStatus.syncing:
+        return Icons.sync;
+      case SyncStatus.idle:
+      default:
+        return Icons.cloud_queue;
+    }
+  }
+
+  static Color? _colorForStatus(ThemeData theme, SyncStatus status) {
+    switch (status) {
+      case SyncStatus.error:
+        return theme.colorScheme.error;
+      case SyncStatus.offline:
+        return theme.colorScheme.outline;
+      case SyncStatus.success:
+        return theme.colorScheme.secondary;
+      case SyncStatus.syncing:
+        return theme.colorScheme.primary;
+      case SyncStatus.idle:
+      default:
+        return theme.colorScheme.primary;
+    }
   }
 }

--- a/bulletin_app/lib/ui/screens/settings_screen.dart
+++ b/bulletin_app/lib/ui/screens/settings_screen.dart
@@ -90,6 +90,51 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             maxLines: 2,
           ),
           const SizedBox(height: 12),
+          FormBuilderTextField(
+            name: 'remoteEndpoint',
+            decoration: const InputDecoration(
+              labelText: 'Serveur de synchronisation (URL)',
+              helperText:
+                  'Exemple: https://mon-serveur/api',
+            ),
+            initialValue: params.remoteEndpoint,
+            validator: FormBuilderValidators.compose([
+              (value) {
+                final trimmed = value?.trim() ?? '';
+                if (trimmed.isEmpty) {
+                  return null;
+                }
+                final uri = Uri.tryParse(trimmed);
+                if (uri == null || !uri.hasScheme) {
+                  return 'URL invalide';
+                }
+                return null;
+              },
+            ]),
+          ),
+          const SizedBox(height: 12),
+          FormBuilderSwitch(
+            name: 'syncEnabled',
+            initialValue: params.syncEnabled,
+            title: const Text('Activer la synchronisation automatique'),
+          ),
+          const SizedBox(height: 12),
+          FormBuilderDropdown<int>(
+            name: 'syncInterval',
+            decoration: const InputDecoration(
+              labelText: 'Fréquence de synchronisation (minutes)',
+            ),
+            initialValue: params.syncIntervalMinutes,
+            items: const [5, 10, 15, 30, 60]
+                .map(
+                  (value) => DropdownMenuItem(
+                    value: value,
+                    child: Text('$value minutes'),
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 12),
           FormBuilderDropdown<UserRole>(
             name: 'role',
             decoration:
@@ -135,6 +180,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       devise: values['devise'] as String? ?? initial.devise,
       langue: values['langue'] as String? ?? initial.langue,
       piedDePage: values['footer'] as String? ?? initial.piedDePage,
+      remoteEndpoint: (values['remoteEndpoint'] as String? ?? '').trim(),
+      syncEnabled: (values['syncEnabled'] as bool? ?? false) &&
+          ((values['remoteEndpoint'] as String? ?? '').trim().isNotEmpty),
+      syncIntervalMinutes:
+          values['syncInterval'] as int? ?? initial.syncIntervalMinutes,
     );
 
     try {

--- a/bulletin_app/pubspec.yaml
+++ b/bulletin_app/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   flex_color_scheme: ^7.2.0
   uuid: ^3.0.7
   equatable: ^2.0.5
+  http: ^1.1.0
+  connectivity_plus: ^5.0.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add remote synchronization support to the data layer with a REST client, repository, and controller
- extend the local database schema and app settings to store sync metadata and remote endpoint configuration
- surface manual/background sync controls in the UI and update dependencies for network connectivity

## Testing
- not run (Flutter SDK unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce7e90f0c88326969ae7b0d0a7b842