### PR TITLE
Fix drift dependencies for Flutter

### DIFF
--- a/bulletin_app/pubspec.yaml
+++ b/bulletin_app/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   flutter_hooks: ^0.18.6
   flutter_form_builder: ^9.1.1
   form_builder_validators: ^9.1.0
-  drift: ^2.12.0
-  drift_flutter: ^2.12.0
+  drift: ^2.11.1
+  drift_flutter: ^2.11.1
   sqlite3_flutter_libs: ^0.5.15
   path: ^1.8.3
   path_provider: ^2.0.15
@@ -34,7 +34,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.0
   build_runner: ^2.4.6
-  drift_dev: ^2.12.0
+  drift_dev: ^2.11.1
   mocktail: ^1.0.0
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- align drift, drift_flutter, and drift_dev dependencies with available releases to resolve pub get failures

## Testing
- flutter pub get *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf121eefa88326bfde90f2ba04a99d