### PR TITLE
Remove unavailable drift_flutter dependency

### DIFF
--- a/bulletin_app/pubspec.yaml
+++ b/bulletin_app/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   flutter_form_builder: ^9.1.1
   form_builder_validators: ^9.1.0
   drift: ^2.11.1
-  drift_flutter: ^2.11.1
   sqlite3_flutter_libs: ^0.5.15
   path: ^1.8.3
   path_provider: ^2.0.15


### PR DESCRIPTION
## Summary
- remove the drift_flutter dependency that is no longer published on pub.dev so that pub get can resolve dependencies

## Testing
- flutter pub get --no-example *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f24893de5083268b2096dbb70ff578