### PR TITLE
Fix Drift database executor selection for web builds

### DIFF
--- a/bulletin_app/lib/data/local/app_database.dart
+++ b/bulletin_app/lib/data/local/app_database.dart
@@ -1,39 +1,16 @@
-// ignore: avoid_web_libraries_in_flutter, unused_import
-import 'dart:io' as io
-    if (dart.library.html) 'dart:html' as html;
-
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
-import 'package:drift/web.dart';
-import 'package:flutter/foundation.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../models/models.dart';
+import 'app_database_executor.dart';
 
 part 'app_database.g.dart';
 
 const _uuid = Uuid();
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final directory = await getApplicationDocumentsDirectory();
-    final file = io.File(p.join(directory.path, 'bulletins.sqlite'));
-    return NativeDatabase.createInBackground(file);
-  });
-}
-
-QueryExecutor _createExecutor() {
-  if (kIsWeb) {
-    return WebDatabase('bulletins_db');
-  }
-  return _openConnection();
-}
-
 @DriftDatabase()
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(_createExecutor());
+  AppDatabase() : super(openConnection());
 
   AppDatabase.forTesting(QueryExecutor executor) : super(executor);
 

--- a/bulletin_app/lib/data/local/app_database_executor.dart
+++ b/bulletin_app/lib/data/local/app_database_executor.dart
@@ -1,0 +1,7 @@
+import 'package:drift/drift.dart';
+
+import 'app_database_executor_stub.dart'
+    if (dart.library.io) 'app_database_executor_io.dart'
+    if (dart.library.html) 'app_database_executor_web.dart';
+
+QueryExecutor openConnection() => createExecutor();

--- a/bulletin_app/lib/data/local/app_database_executor_io.dart
+++ b/bulletin_app/lib/data/local/app_database_executor_io.dart
@@ -1,0 +1,16 @@
+import 'dart:io' as io;
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final directory = await getApplicationDocumentsDirectory();
+    final file = io.File(p.join(directory.path, 'bulletins.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}
+
+QueryExecutor createExecutor() => _openConnection();

--- a/bulletin_app/lib/data/local/app_database_executor_stub.dart
+++ b/bulletin_app/lib/data/local/app_database_executor_stub.dart
@@ -1,0 +1,4 @@
+import 'package:drift/drift.dart';
+
+QueryExecutor createExecutor() =>
+    throw UnsupportedError('No database executor available for this platform.');

--- a/bulletin_app/lib/data/local/app_database_executor_web.dart
+++ b/bulletin_app/lib/data/local/app_database_executor_web.dart
@@ -1,0 +1,4 @@
+import 'package:drift/drift.dart';
+import 'package:drift/web.dart';
+
+QueryExecutor createExecutor() => WebDatabase('bulletins_db');


### PR DESCRIPTION
## Summary
- move the Drift database executor selection into platform-specific helpers
- avoid importing the sqlite3-backed native executor on Flutter web builds

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f25118e1f88326ae0dad0c7b723ad9