### PR TITLE
Fix build errors for sync provider and drift null handling

### DIFF
--- a/bulletin_app/lib/main.dart
+++ b/bulletin_app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -62,8 +64,8 @@ class BulletinApp extends ConsumerWidget {
       initialRoute: FactureListScreen.routeName,
       builder: (context, child) {
         final direction = locale.languageCode == 'ar'
-            ? TextDirection.rtl
-            : TextDirection.ltr;
+            ? ui.TextDirection.rtl
+            : ui.TextDirection.ltr;
         return Directionality(textDirection: direction, child: child!);
       },
     );

--- a/bulletin_app/lib/ui/screens/facture_list_screen.dart
+++ b/bulletin_app/lib/ui/screens/facture_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import '../../data/models/models.dart';
 import '../../data/repositories/sync_repository.dart';
+import '../../logic/providers/app_bootstrap_provider.dart';
 import '../../logic/providers/current_facture_provider.dart';
 import '../../logic/providers/factures_list_provider.dart';
 import '../../logic/providers/sync_controller.dart';


### PR DESCRIPTION
## Summary
- ensure the app builder uses the `dart:ui` text direction constants to avoid missing member errors
- import the bootstrap provider so the sync controller is available to the facture list screen
- update raw inserts in the Drift database to use `customStatement` so nullable columns are passed correctly and adjust metadata reading

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2592d842c832683da0ae368908a72