### PR TITLE
Add role selection landing page for bulletin app

### DIFF
--- a/bulletin_app/lib/main.dart
+++ b/bulletin_app/lib/main.dart
@@ -8,9 +8,13 @@ import 'package:intl/intl.dart';
 
 import 'logic/providers/app_bootstrap_provider.dart';
 import 'logic/providers/locale_provider.dart';
+import 'ui/screens/admin_dashboard_screen.dart';
 import 'ui/screens/facture_edit_screen.dart';
 import 'ui/screens/facture_list_screen.dart';
+import 'ui/screens/role_selection_screen.dart';
 import 'ui/screens/settings_screen.dart';
+import 'ui/screens/supplier_dashboard_screen.dart';
+import 'ui/screens/vendor_dashboard_screen.dart';
 import 'ui/theming/app_theme.dart';
 
 void main() {
@@ -48,20 +52,36 @@ class BulletinApp extends ConsumerWidget {
       ],
       onGenerateRoute: (settings) {
         switch (settings.name) {
+          case AdminDashboardScreen.routeName:
+            return MaterialPageRoute(
+              builder: (_) => const AdminDashboardScreen(),
+            );
           case FactureEditScreen.routeName:
             return MaterialPageRoute(
               builder: (_) => FactureEditScreen(
                 factureId: settings.arguments as String?,
               ),
             );
+          case RoleSelectionScreen.routeName:
+            return MaterialPageRoute(
+              builder: (_) => const RoleSelectionScreen(),
+            );
           case SettingsScreen.routeName:
             return MaterialPageRoute(builder: (_) => const SettingsScreen());
+          case SupplierDashboardScreen.routeName:
+            return MaterialPageRoute(
+              builder: (_) => const SupplierDashboardScreen(),
+            );
+          case VendorDashboardScreen.routeName:
+            return MaterialPageRoute(
+              builder: (_) => const VendorDashboardScreen(),
+            );
           case FactureListScreen.routeName:
           default:
             return MaterialPageRoute(builder: (_) => const FactureListScreen());
         }
       },
-      initialRoute: FactureListScreen.routeName,
+      initialRoute: RoleSelectionScreen.routeName,
       builder: (context, child) {
         final direction = locale.languageCode == 'ar'
             ? ui.TextDirection.rtl

--- a/bulletin_app/lib/ui/screens/admin_dashboard_screen.dart
+++ b/bulletin_app/lib/ui/screens/admin_dashboard_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class AdminDashboardScreen extends StatelessWidget {
+  const AdminDashboardScreen({super.key});
+
+  static const routeName = '/admin-dashboard';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Espace administrateur'),
+      ),
+      body: const Center(
+        child: Text(
+          'Bienvenue dans l\'espace administrateur',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/bulletin_app/lib/ui/screens/role_selection_screen.dart
+++ b/bulletin_app/lib/ui/screens/role_selection_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import 'admin_dashboard_screen.dart';
+import 'supplier_dashboard_screen.dart';
+import 'vendor_dashboard_screen.dart';
+
+class RoleSelectionScreen extends StatelessWidget {
+  const RoleSelectionScreen({super.key});
+
+  static const routeName = '/role-selection';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Choisir un rôle'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: const [
+            _RoleCard(
+              title: 'Administrateur',
+              description: 'Gérer les paramètres et la configuration.',
+              routeName: AdminDashboardScreen.routeName,
+            ),
+            SizedBox(height: 16),
+            _RoleCard(
+              title: 'Vendeur',
+              description: 'Créer et consulter les factures de vente.',
+              routeName: VendorDashboardScreen.routeName,
+            ),
+            SizedBox(height: 16),
+            _RoleCard(
+              title: 'Fournisseur',
+              description: 'Suivre les livraisons et les approvisionnements.',
+              routeName: SupplierDashboardScreen.routeName,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoleCard extends StatelessWidget {
+  const _RoleCard({
+    required this.title,
+    required this.description,
+    required this.routeName,
+  });
+
+  final String title;
+  final String description;
+  final String routeName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 3,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => Navigator.of(context).pushNamed(routeName),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                description,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  'Accéder',
+                  style: Theme.of(context)
+                      .textTheme
+                      .labelLarge
+                      ?.copyWith(color: Theme.of(context).colorScheme.primary),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/bulletin_app/lib/ui/screens/supplier_dashboard_screen.dart
+++ b/bulletin_app/lib/ui/screens/supplier_dashboard_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class SupplierDashboardScreen extends StatelessWidget {
+  const SupplierDashboardScreen({super.key});
+
+  static const routeName = '/supplier-dashboard';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Espace fournisseur'),
+      ),
+      body: const Center(
+        child: Text(
+          'Bienvenue dans l\'espace fournisseur',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/bulletin_app/lib/ui/screens/vendor_dashboard_screen.dart
+++ b/bulletin_app/lib/ui/screens/vendor_dashboard_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class VendorDashboardScreen extends StatelessWidget {
+  const VendorDashboardScreen({super.key});
+
+  static const routeName = '/vendor-dashboard';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Espace vendeur'),
+      ),
+      body: const Center(
+        child: Text(
+          'Bienvenue dans l\'espace vendeur',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a landing screen that lets the user choose between administrateur, vendeur, or fournisseur roles
- provide placeholder dashboard screens for each role with navigation targets
- update the app routing to open the role selection before existing facture and settings pages

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f25b4e52288326aca556de9990e6f4