### PR TITLE
Update role selection navigation

### DIFF
--- a/bulletin_app/lib/ui/screens/role_selection_screen.dart
+++ b/bulletin_app/lib/ui/screens/role_selection_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'admin_dashboard_screen.dart';
+import 'facture_list_screen.dart';
 import 'supplier_dashboard_screen.dart';
-import 'vendor_dashboard_screen.dart';
 
 class RoleSelectionScreen extends StatelessWidget {
   const RoleSelectionScreen({super.key});
@@ -28,7 +28,7 @@ class RoleSelectionScreen extends StatelessWidget {
             _RoleCard(
               title: 'Vendeur',
               description: 'Créer et consulter les factures de vente.',
-              routeName: VendorDashboardScreen.routeName,
+              routeName: FactureListScreen.routeName,
             ),
             SizedBox(height: 16),
             _RoleCard(
@@ -60,7 +60,7 @@ class _RoleCard extends StatelessWidget {
       elevation: 3,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () => Navigator.of(context).pushNamed(routeName),
+        onTap: () => Navigator.of(context).pushReplacementNamed(routeName),
         child: Padding(
           padding: const EdgeInsets.all(20),
           child: Column(


### PR DESCRIPTION
## Summary
- route the vendor role directly to the invoice list screen
- replace the role selection screen when navigating to a chosen role

## Testing
- not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f25d83bf388326948a3dec4dc1158f