### PR TITLE
Include Drift web assets for Flutter web builds

### DIFF
--- a/bulletin_app/pubspec.yaml
+++ b/bulletin_app/pubspec.yaml
@@ -40,4 +40,8 @@ flutter:
   assets:
     - assets/logo/
     - assets/fonts/
+    - packages/drift/web/worker.dart.js
+    - packages/drift/web/worker.dart.js.map
+    - packages/drift/web/wasm/sql-wasm.wasm
+    - packages/drift/web/wasm/sql-wasm.js
   generate: true


### PR DESCRIPTION
## Summary
- add the drift web worker and wasm assets to the Flutter asset bundle so sql.js can be loaded on the web

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f25f5b2628832690097e929ec11e2e