### PR TITLE
Downgrade drift dependencies for web asset availability

### DIFF
--- a/bulletin_app/pubspec.yaml
+++ b/bulletin_app/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_hooks: ^0.18.6
   flutter_form_builder: ^9.1.1
   form_builder_validators: ^9.1.0
-  drift: ^2.11.1
+  drift: 2.10.0
   sqlite3_flutter_libs: ^0.5.15
   path: ^1.8.3
   path_provider: ^2.0.15
@@ -33,7 +33,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.0
   build_runner: ^2.4.6
-  drift_dev: ^2.11.1
+  drift_dev: 2.10.0
   mocktail: ^1.0.0
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- downgrade `drift` and `drift_dev` to version 2.10.0 so Flutter can locate the packaged web worker assets during builds

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2650585a08326b806ed07a198bc77