### PR TITLE
Fix drift web database wasm asset path

### DIFF
--- a/bulletin_app/lib/data/local/app_database_executor_web.dart
+++ b/bulletin_app/lib/data/local/app_database_executor_web.dart
@@ -1,4 +1,8 @@
 import 'package:drift/drift.dart';
 import 'package:drift/web.dart';
 
-QueryExecutor createExecutor() => WebDatabase('bulletins_db');
+QueryExecutor createExecutor() => WebDatabase.withStorage(
+      DriftWebStorage.indexedDb('bulletins_db'),
+      sqlite3WasmUri:
+          Uri.parse('assets/packages/drift/web/wasm/sql-wasm.wasm'),
+    );


### PR DESCRIPTION
## Summary
- configure the Drift web database to use IndexedDB storage
- point Drift to the bundled sql.js wasm asset so the library can be loaded on web

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f294040260832697f10d5372099644