### PR TITLE
Fix drift WebDatabase wasm parameter name

### DIFF
--- a/bulletin_app/lib/data/local/app_database_executor_web.dart
+++ b/bulletin_app/lib/data/local/app_database_executor_web.dart
@@ -3,6 +3,5 @@ import 'package:drift/web.dart';
 
 QueryExecutor createExecutor() => WebDatabase.withStorage(
       DriftWebStorage.indexedDb('bulletins_db'),
-      sqlite3WasmUri:
-          Uri.parse('assets/packages/drift/web/wasm/sql-wasm.wasm'),
+      sqlite3Uri: Uri.parse('assets/packages/drift/web/wasm/sql-wasm.wasm'),
     );


### PR DESCRIPTION
## Summary
- update the web database executor to use the current sqlite3Uri parameter for the wasm bundle

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f296b0228c83269c2e83804bc871d2